### PR TITLE
chore: remove Imprint link from footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -44,7 +44,6 @@
         <li><a href="#" class="prose-link">Privacy Policy</a></li>
         <li><a href="#" class="prose-link">Terms of Service</a></li>
         <li><a href="#" class="prose-link">Cookie Policy</a></li>
-        <li><a href="#" class="prose-link">Imprint</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Drops the `Imprint` entry from the bottom-bar legal links in `layouts/partials/footer.html`.

## Before

```html
<ul class="flex gap-6">
  <li><a href="#" class="prose-link">Privacy Policy</a></li>
  <li><a href="#" class="prose-link">Terms of Service</a></li>
  <li><a href="#" class="prose-link">Cookie Policy</a></li>
  <li><a href="#" class="prose-link">Imprint</a></li>
</ul>
```

## After

```html
<ul class="flex gap-6">
  <li><a href="#" class="prose-link">Privacy Policy</a></li>
  <li><a href="#" class="prose-link">Terms of Service</a></li>
  <li><a href="#" class="prose-link">Cookie Policy</a></li>
</ul>
```

## Verification

`hugo --minify` builds clean, 14 pages, 85 ms. No other references to "Imprint" in the repo:

```bash
$ grep -R Imprint .
(no matches)
```