### PR TITLE
chore(analytics): switch GA4 measurement ID to 2060 property

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -61,14 +61,12 @@
 {{- /*
   Google tag (gtag.js). Loaded async so it never blocks first paint;
   pageview hit fires automatically on `gtag('config', ...)`.
-  NOTE: the measurement ID below is shared with verana.io, swap in a
-  2060-specific GA4 property when one is provisioned.
 */ -}}
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-9H5406F02W"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-0NZTBWRYRW"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'G-9H5406F02W');
+  gtag('config', 'G-0NZTBWRYRW');
 </script>


### PR DESCRIPTION
## Summary

Swaps the shared verana.io measurement ID for 2060's own GA4 property so traffic to `2060.io` lands in the correct data stream.

| | |
|---|---|
| **Before** | `G-9H5406F02W` (verana.io, shared temporarily per PR #46 TODO) |
| **After** | `G-0NZTBWRYRW` (2060-specific GA4 property) |

Also drops the `NOTE:` comment in `layouts/partials/head.html` that flagged this as a pending swap.

## Files

Single file, two matching replacements (loader URL + `gtag('config', ...)`):

```text
 layouts/partials/head.html | 6 ++----
 1 file changed, 2 insertions(+), 4 deletions(-)
```

## Verification

```bash
$ npm run build
Total in 18 ms

$ grep -o 'G-[0-9A-Z]*' public/**/*.html | awk -F: '{print $2}' | sort -u
G-0NZTBWRYRW

$ grep -r 'G-9H5406F02W' public/ layouts/
(no matches)
```

Tag fires on all 8 rendered pages: `/`, `/services/`, `/projects/`, `/research/`, `/team/`, `/contact/`, `/privacy-policy/`, `/terms-of-service/`.

## After merge

- Real-Time report in GA4 property `G-0NZTBWRYRW` should start showing 2060.io hits within ~30 s of the GitHub Pages deploy completing.
- Verana's property stops receiving 2060.io pageviews (confirming the swap worked).