### PR TITLE
feat(deploy): Helm chart + CD workflow for 2060.io

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,88 @@
+name: Deploy to Kubernetes
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Image tag to deploy (e.g. 1.2.3 or latest)"
+        required: true
+        default: latest
+
+concurrency:
+  group: cd-${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compute image tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # release tag is of the form v1.2.3 — drop the leading v
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="${{ inputs.version }}"
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not determine image tag to deploy."
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Deploying io2060/website:$VERSION"
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Write kubeconfig
+        env:
+          KUBECONFIG_DATA: ${{ vars.OVH_KUBERNETES }}
+        run: |
+          if [ -z "$KUBECONFIG_DATA" ]; then
+            echo "::error::The OVH_KUBERNETES GitHub Actions variable is empty."
+            echo "Set it under Settings → Secrets and variables → Actions → Variables."
+            exit 1
+          fi
+          mkdir -p "$HOME/.kube"
+          printf '%s' "$KUBECONFIG_DATA" > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+          kubectl cluster-info
+
+      - name: Wait for Docker image to be available on Docker Hub
+        run: |
+          IMAGE="io2060/website:${{ steps.tag.outputs.version }}"
+          for i in $(seq 1 10); do
+            if docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
+              echo "Image $IMAGE is available."
+              exit 0
+            fi
+            echo "[$i/10] Image $IMAGE not yet available on Docker Hub, waiting 30s..."
+            sleep 30
+          done
+          echo "::error::Image $IMAGE was not available after ~5 minutes."
+          exit 1
+
+      - name: Helm upgrade
+        run: |
+          helm upgrade --install website ./charts \
+            --namespace web \
+            --create-namespace \
+            --set image.tag=${{ steps.tag.outputs.version }} \
+            --wait --timeout 5m
+
+      - name: Show deployed resources
+        if: always()
+        run: |
+          helm status website -n web || true
+          kubectl -n web get deploy,svc,ingress -l app.kubernetes.io/name=website -o wide || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Image tag to deploy (e.g. 1.2.3 or latest)"
+        description: "Image tag to deploy (e.g. v1.2.3, v1, dev, latest)"
         required: true
         default: latest
 
@@ -25,8 +25,10 @@ jobs:
         id: tag
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
-            # release tag is of the form v1.2.3 — drop the leading v
-            VERSION="${GITHUB_REF_NAME#v}"
+            # release-please tags releases 'v1.2.3' and the Docker workflow
+            # in cd.yml pushes io2060/website:v1.2.3 with the same name,
+            # so use the ref name as-is (no 'v' stripping).
+            VERSION="${GITHUB_REF_NAME}"
           else
             VERSION="${{ inputs.version }}"
           fi

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: website
+description: Helm chart that deploys the 2060.io Next.js website behind an nginx ingress with Let's Encrypt TLS.
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,41 @@
+# 2060.io website — Helm chart
+
+Deploys the 2060.io corporate website (Next.js 15 standalone) behind an
+nginx ingress with Let's Encrypt TLS.
+
+## Defaults
+
+| Key | Value |
+| --- | --- |
+| `image.repository` | `io2060/website` |
+| `image.tag` | empty → `Chart.AppVersion` |
+| `replicaCount` | `2` |
+| `service.type` | `ClusterIP` |
+| `service.port` | `80` |
+| `service.targetPort` | `3000` (Next.js standalone listens on 3000) |
+| `ingress.className` | `nginx` |
+| `ingress.host` | `2060.io` |
+| `ingress.tls.enabled` | `true` |
+| `ingress.tls.secretName` | `website-2060-io-tls` |
+| `ingress.annotations` | `cert-manager.io/cluster-issuer: letsencrypt-prod` |
+
+## Install
+
+```bash
+helm upgrade --install website ./charts \
+  --namespace web \
+  --create-namespace \
+  --set image.tag=v1.0.0
+```
+
+## CI
+
+Deployment is triggered automatically by `.github/workflows/cd.yml` on every
+published GitHub release. It authenticates against the OVH cluster using the
+`OVH_KUBERNETES` GitHub Actions variable.
+
+> **Security note:** `OVH_KUBERNETES` is a Variable (not a Secret) per the
+> current configuration. A kubeconfig grants cluster access and is usually
+> stored as a Secret. If the value contains raw kubeconfig credentials,
+> consider moving it to `${{ secrets.OVH_KUBERNETES }}` and updating the
+> workflow accordingly.

--- a/charts/README.md
+++ b/charts/README.md
@@ -8,7 +8,7 @@ nginx ingress with Let's Encrypt TLS.
 | Key | Value |
 | --- | --- |
 | `image.repository` | `io2060/website` |
-| `image.tag` | empty → `Chart.AppVersion` |
+| `image.tag` | empty → `v<Chart.AppVersion>` (e.g. `v1.0.0`) |
 | `replicaCount` | `2` |
 | `service.type` | `ClusterIP` |
 | `service.port` | `80` |
@@ -25,13 +25,14 @@ nginx ingress with Let's Encrypt TLS.
 helm upgrade --install website ./charts \
   --namespace web \
   --create-namespace \
-  --set image.tag=v1.0.0
+  --set image.tag=v1.0.0   # or leave unset to default to v<AppVersion>, or use 'latest' / 'dev'
 ```
 
 ## CI
 
-Deployment is triggered automatically by `.github/workflows/cd.yml` on every
-published GitHub release. It authenticates against the OVH cluster using the
+Deployment is triggered automatically by `.github/workflows/deploy.yml` on
+every published GitHub release (the companion `.github/workflows/cd.yml`
+builds the image). It authenticates against the OVH cluster using the
 `OVH_KUBERNETES` GitHub Actions variable.
 
 > **Security note:** `OVH_KUBERNETES` is a Variable (not a Secret) per the

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "website.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified app name.
+*/}}
+{{- define "website.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart label (<name>-<version>) used by Helm.
+*/}}
+{{- define "website.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "website.labels" -}}
+helm.sh/chart: {{ include "website.chart" . }}
+{{ include "website.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "website.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "website.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       {{- end }}
       containers:
         - name: website
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.securityContext }}
           securityContext:

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "website.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "website.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "website.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "website.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: website
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          env:
+            {{- range .Values.env }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/templates/ingress.yaml
+++ b/charts/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "website.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "website.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "website.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "website.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "website.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "website.selectorLabels" . | nindent 4 }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,0 +1,68 @@
+# Default values for the 2060.io website Helm chart.
+
+nameOverride: "website"
+fullnameOverride: ""
+
+image:
+  repository: io2060/website
+  # tag defaults to Chart.AppVersion when empty
+  tag: ""
+  pullPolicy: IfNotPresent
+
+replicaCount: 2
+
+resources:
+  requests:
+    cpu: "50m"
+    memory: "128Mi"
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+
+service:
+  type: ClusterIP
+  port: 80
+  # The Next.js standalone server listens on 3000.
+  targetPort: 3000
+
+ingress:
+  enabled: true
+  className: nginx
+  host: 2060.io
+  tls:
+    enabled: true
+    secretName: website-2060-io-tls
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+
+# Container env for the Node.js runtime.
+env:
+  - name: NODE_ENV
+    value: production
+  - name: PORT
+    value: "3000"
+  - name: HOSTNAME
+    value: 0.0.0.0
+
+# Health probes hit the Next.js app root, which is statically prerendered and
+# always returns 200 once the standalone server is listening.
+probes:
+  liveness:
+    path: /
+    initialDelaySeconds: 15
+    periodSeconds: 30
+    timeoutSeconds: 3
+    failureThreshold: 3
+  readiness:
+    path: /
+    initialDelaySeconds: 3
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+
+podSecurityContext: {}
+securityContext: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -5,7 +5,8 @@ fullnameOverride: ""
 
 image:
   repository: io2060/website
-  # tag defaults to Chart.AppVersion when empty
+  # tag defaults to "v<Chart.AppVersion>" when empty, matching the Docker
+  # tags produced by .github/workflows/cd.yml (e.g. v1.0.0).
   tag: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Adds a Helm chart and a GitHub Actions CD workflow that deploys the site to Kubernetes whenever a new GitHub release is published.

> **Order of merge.** This PR is additive and branches from `main`. It should be merged **after** #51 (the Hugo → Next.js migration) since it deploys the `io2060/website` image that #51 introduces. Nothing breaks if merged first — the workflow simply has no image to pull until the first release on the new stack is cut.

## Chart — `charts/`

| File | Purpose |
| --- | --- |
| `Chart.yaml` | `apiVersion: v2`, `type: application`, `version: 0.1.0`, `appVersion: 1.0.0` |
| `values.yaml` | Image `io2060/website`, 2 replicas, probes on `/`, ingress host `2060.io` |
| `README.md` | Defaults, install command, security note on `OVH_KUBERNETES` |
| `templates/_helpers.tpl` | Standard `website.name` / `website.fullname` / labels helpers |
| `templates/deployment.yaml` | 2 replicas, liveness + readiness on `/`, cpu/mem requests + limits |
| `templates/service.yaml` | `ClusterIP` on `:80` → `targetPort: http` (container port 3000) |
| `templates/ingress.yaml` | `ingressClassName: nginx`, TLS via cert-manager `letsencrypt-prod`, host `2060.io`, secret `website-2060-io-tls` |

Verified locally:

```
helm lint ./charts                 # 1 chart(s) linted, 0 failed
helm template website ./charts -n web --set image.tag=1.0.0   # renders cleanly
```

## Workflow — `.github/workflows/cd.yml`

Triggers:

- `release: [published]` — runs automatically on every release-please release.
- `workflow_dispatch` with an `version` input — for manual redeploys.

Steps:

1. Compute image tag (`${GITHUB_REF_NAME#v}` for releases, or the dispatch input).
2. Install `kubectl` (`azure/setup-kubectl@v4`) and `helm` (`azure/setup-helm@v4`, `v3.14.0`).
3. Write `~/.kube/config` from `${{ vars.OVH_KUBERNETES }}` and run `kubectl cluster-info` as a sanity check.
4. Wait up to ~5 min for `io2060/website:<version>` to appear on Docker Hub (avoids racing the `docker-release` job that runs in parallel).
5. `helm upgrade --install website ./charts --namespace web --create-namespace --set image.tag=<version> --wait --timeout 5m`.
6. Print `helm status` and `kubectl get deploy,svc,ingress` for the release (always, so failures are easy to diagnose).

`concurrency: group: cd-${{ github.workflow }}` prevents overlapping deploys if two releases land close together.

## Required GitHub Actions configuration

| Kind | Name | Used in |
| --- | --- | --- |
| Variable | `OVH_KUBERNETES` | raw kubeconfig written to `~/.kube/config` |

> **Security note.** A kubeconfig grants cluster admin access and is normally stored as a **Secret**, not a **Variable** (Variables are 48 KB, readable by anyone with read access to workflow runs, and not masked in logs). The workflow and README honor the Variable name as requested; if the value contains real credentials, consider moving it to `secrets.OVH_KUBERNETES` and flipping one line in `cd.yml`.

## Cluster expectations

The workflow assumes the target cluster has:

- `ingressClassName: nginx` (ingress-nginx controller installed).
- `cert-manager` with a `ClusterIssuer` named `letsencrypt-prod`.
- DNS for `2060.io` pointing at the nginx ingress LB.

All three are already in use by other `2060-io` deployments (e.g. `hologram-gov-id-issuer-vs`).
