### PR TITLE
fix(deploy): use `secrets.OVH_KUBECONFIG` for cluster auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,11 +49,11 @@ jobs:
 
       - name: Write kubeconfig
         env:
-          KUBECONFIG_DATA: ${{ vars.OVH_KUBERNETES }}
+          KUBECONFIG_DATA: ${{ secrets.OVH_KUBECONFIG }}
         run: |
           if [ -z "$KUBECONFIG_DATA" ]; then
-            echo "::error::The OVH_KUBERNETES GitHub Actions variable is empty."
-            echo "Set it under Settings → Secrets and variables → Actions → Variables."
+            echo "::error::The OVH_KUBECONFIG GitHub Actions secret is empty."
+            echo "Set it under Settings → Secrets and variables → Actions → Secrets."
             exit 1
           fi
           mkdir -p "$HOME/.kube"

--- a/charts/README.md
+++ b/charts/README.md
@@ -33,10 +33,9 @@ helm upgrade --install website ./charts \
 Deployment is triggered automatically by `.github/workflows/deploy.yml` on
 every published GitHub release (the companion `.github/workflows/cd.yml`
 builds the image). It authenticates against the OVH cluster using the
-`OVH_KUBERNETES` GitHub Actions variable.
+`OVH_KUBECONFIG` GitHub Actions **secret** (raw kubeconfig contents,
+masked in logs).
 
-> **Security note:** `OVH_KUBERNETES` is a Variable (not a Secret) per the
-> current configuration. A kubeconfig grants cluster access and is usually
-> stored as a Secret. If the value contains raw kubeconfig credentials,
-> consider moving it to `${{ secrets.OVH_KUBERNETES }}` and updating the
-> workflow accordingly.
+Set it under *Settings → Secrets and variables → Actions → Secrets →
+New repository secret*, name `OVH_KUBECONFIG`, value the full kubeconfig
+YAML.


### PR DESCRIPTION
Move the kubeconfig reference from a GitHub Actions **Variable** (`vars.OVH_KUBERNETES`) to a **Secret** (`secrets.OVH_KUBECONFIG`). Kubeconfigs grant cluster access and must live in Secrets — Variables are 48 KB, unmasked in logs, and visible to anyone who can read a workflow run.

## Changes

- **`.github/workflows/deploy.yml`**: `${{ vars.OVH_KUBERNETES }}` → `${{ secrets.OVH_KUBECONFIG }}`; error message updated (`"The OVH_KUBECONFIG GitHub Actions secret is empty."`).
- **`charts/README.md`**: CI section now points at the new secret name; the previous "consider moving this to a Secret" caveat is resolved and removed.

## Required config change

Under *Settings → Secrets and variables → Actions*:

1. Add **Secret** `OVH_KUBECONFIG` with the full kubeconfig YAML as the value.
2. The old **Variable** `OVH_KUBERNETES` is no longer referenced and can be deleted.

## Rollout

Because the first real deploy hasn't happened yet (no successful `deploy.yml` run so far — the v2.0.0 and v2.1.0 releases will have failed on the `Write kubeconfig` step with the old Variable unset), this PR is effectively the last piece needed before the first green deploy. Merging it plus setting `OVH_KUBECONFIG` means the next release will deploy cleanly.
