### PR TITLE
perf(nav): cache /assets/* and /images/*, and start preload earlier

### DIFF
--- a/app/components/ImagePreloader.tsx
+++ b/app/components/ImagePreloader.tsx
@@ -83,6 +83,10 @@ export default function ImagePreloader() {
         link.rel = "prefetch";
         link.as = "image";
         link.href = href;
+        // Keep it explicitly deprioritized so it never competes with the
+        // current page's in-flight resources. `rel="prefetch"` is already
+        // low-priority per the spec; fetchPriority pins it.
+        link.setAttribute("fetchpriority", "low");
         document.head.appendChild(link);
       });
       try {
@@ -92,26 +96,23 @@ export default function ImagePreloader() {
       }
     }
 
-    function schedule() {
-      const ric = (
-        window as Window & {
-          requestIdleCallback?: (
-            cb: () => void,
-            opts?: { timeout?: number }
-          ) => number;
-        }
-      ).requestIdleCallback;
-      if (typeof ric === "function") {
-        ric(prefetchAll, { timeout: 3000 });
-      } else {
-        setTimeout(prefetchAll, 1000);
+    // Run as soon as this component mounts (i.e. right after hydration).
+    // rel="prefetch" fetchpriority="low" is low-priority, so it won't
+    // compete with the current page's critical resources; firing here
+    // instead of waiting for window.load + requestIdleCallback cuts
+    // 1-3 seconds off the time-to-cache for cross-page images.
+    const ric = (
+      window as Window & {
+        requestIdleCallback?: (
+          cb: () => void,
+          opts?: { timeout?: number }
+        ) => number;
       }
-    }
-
-    if (document.readyState === "complete") {
-      schedule();
+    ).requestIdleCallback;
+    if (typeof ric === "function") {
+      ric(prefetchAll, { timeout: 500 });
     } else {
-      window.addEventListener("load", schedule, { once: true });
+      setTimeout(prefetchAll, 0);
     }
   }, []);
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,40 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   output: "standalone",
   reactStrictMode: true,
+
+  // By default Next.js serves everything under `public/` with
+  // `Cache-Control: public, max-age=0`, which forces the browser to
+  // revalidate every image on every navigation (conditional GET → 304,
+  // still an RTT to the origin). Override so cross-page assets render
+  // from cache with zero network trips after the first visit.
+  async headers() {
+    return [
+      {
+        // Site illustrations, team portraits, logos, theme toggle JS,
+        // og-image, favicon. These can be refreshed across a release,
+        // so we keep freshness bounded but allow stale-while-revalidate
+        // so users never block on a background refresh.
+        source: "/assets/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=86400, stale-while-revalidate=604800",
+          },
+        ],
+      },
+      {
+        // Legacy /images/* paths preserved for backward compatibility
+        // with inbound links from the old Hugo site — these never change.
+        source: "/images/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=604800, stale-while-revalidate=2592000",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Root cause of the ~400 ms click-to-image latency

Next.js serves everything under `public/` with `Cache-Control: public, max-age=0` by default. So even though `ImagePreloader` does put images in the HTTP cache, **every navigation triggers a conditional-GET revalidation** (`304 Not Modified`) on every image on the destination page. That revalidation round-trip is the ~400 ms you were measuring.

Secondary issue: `ImagePreloader` waited for `window.load` **plus** `requestIdleCallback` before starting to prefetch. On a realistic page that's 1–3 s of dead time before prefetch even begins — long enough that an impatient user can click a nav link before the destination page's images have entered the cache.

## Fix 1 — `next.config.ts` adds `headers()`

| Path | `Cache-Control` |
| --- | --- |
| `/assets/:path*` | `public, max-age=86400, stale-while-revalidate=604800` &nbsp; *(1-day fresh, 7-day SWR)* |
| `/images/:path*` | `public, max-age=604800, stale-while-revalidate=2592000` &nbsp; *(7-day fresh, 30-day SWR — these are legacy backward-compat paths that never change)* |

Cached assets are served from memory/disk with **no network trip**. Background `stale-while-revalidate` keeps them fresh without blocking nav.

## Fix 2 — `ImagePreloader.tsx` starts sooner

- Drops the `window.load` gate; fires right after hydration.
- Keeps `requestIdleCallback` but lowers the timeout from `3000` → `500` ms so the prefetch goes out quickly on idle machines.
- Adds `fetchpriority="low"` on each `<link rel="prefetch">`, so the prefetch still never competes with the current page's critical resources.

## Expected effect

- **First nav in a session (cold)** → images are in the HTTP cache by the time you click. First nav feels fast.
- **Every subsequent nav (warm)** → served straight from cache with no revalidation. Click-to-image goes from ~400 ms to ~0 ms.

## Verification after deploy

```
curl -I https://2060.io/assets/team.svg
# expect:  Cache-Control: public, max-age=86400, stale-while-revalidate=604800

curl -I https://2060.io/images/avatar.jpg
# expect:  Cache-Control: public, max-age=604800, stale-while-revalidate=2592000
```

DevTools → Network → filter "img" → click around. On a warm session, Size column should read `(memory cache)` or `(disk cache)` and Time should be ≤ 1 ms per image.
