### PR TITLE
polish(home): tighten hero size and rephrase headline

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,7 +8,7 @@ import Analytics from "./components/Analytics";
 
 const SITE_URL = "https://2060.io";
 const SITE_NAME = "2060";
-const SITE_TITLE = "2060 — We Build the Open Trust Layer for the Agentic Internet";
+const SITE_TITLE = "2060 — We Build the Open Trust Layer for the Agentic Era";
 const SITE_DESCRIPTION =
   "An independent research and engineering company inventing, specifying, and shipping the infrastructure that lets humans, services, and AI agents prove who they are and act under verifiable authority.";
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -186,8 +186,8 @@ export default function Page() {
         <p className="text-xs text-muted tracking-wide uppercase">
           Open Source · Founding Member of the Verana Foundation · Production Stack in Market
         </p>
-        <h1 className="display text-4xl md:text-6xl lg:text-7xl leading-[1.05] max-w-5xl mx-auto mt-6">
-          We Build the Open Trust Layer for the Agentic Internet
+        <h1 className="display text-3xl md:text-5xl lg:text-6xl leading-[1.1] max-w-4xl mx-auto mt-6">
+          We Build the Open Trust Layer for the Agentic Era
         </h1>
         <div className="accent-line mx-auto mt-6"></div>
         <p className="text-lg md:text-xl text-muted reading max-w-2xl mx-auto mt-8">


### PR DESCRIPTION
Two related polish tweaks to the home hero.

## 1. Type scale — one step down at every breakpoint

| | before | after |
| --- | --- | --- |
| mobile | `text-4xl` (36 px) | `text-3xl` (30 px) |
| `md` | `text-6xl` (60 px) | `text-5xl` (48 px) |
| `lg` | `text-7xl` (72 px) | `text-6xl` (60 px) |
| leading | `[1.05]` | `[1.1]` |
| max-width | `max-w-5xl` (1024 px) | `max-w-4xl` (896 px) |

Rationale: the previous sizes were dramatically larger than everything else on the site — section H2s are `text-3xl md:text-4xl`. The new scale keeps the hero clearly the lead heading while sitting inside the same editorial type system instead of above it. Slight leading bump + narrower max-width make the smaller block feel intentional rather than shrunk.

## 2. Wording — "Agentic Internet" → "Agentic Era"

Drops `Internet` per user direction and replaces with `Era`, which is civilisational-scale and medium-neutral (not tied to the web, a device, or an app). Updated in both places that held the phrase so the visible H1, browser tab, OpenGraph card, Twitter card, and schema.org graph all stay in sync:

- `app/page.tsx` — the visible hero H1
- `app/layout.tsx` — `SITE_TITLE` constant (single source of truth for title / OG / Twitter / schema.org)

## Verification

- `npm run build` passes; all 8 pages still statically prerender.
- Grepped `Agentic Internet` across `**/*.{ts,tsx,md}` — only the two files above referenced it, both updated.
