### PR TITLE
chore(deploy): single replica, force repull and restart on each upgrade

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -14,6 +14,12 @@ spec:
     metadata:
       labels:
         {{- include "website.selectorLabels" . | nindent 8 }}
+      annotations:
+        # Forces a pod rollout on every `helm upgrade`, even when the image
+        # tag is unchanged. Paired with image.pullPolicy=Always in values.yaml
+        # so the replacement pod always repulls the image from the registry.
+        # See: https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
       {{- with .Values.podSecurityContext }}
       securityContext:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -8,9 +8,14 @@ image:
   # tag defaults to "v<Chart.AppVersion>" when empty, matching the Docker
   # tags produced by .github/workflows/cd.yml (e.g. v1.0.0).
   tag: ""
-  pullPolicy: IfNotPresent
+  # Always repull on pod creation so a redeploy against a mutable tag
+  # (dev, latest, v1) still picks up the newest image.
+  pullPolicy: Always
 
-replicaCount: 2
+# Marketing site; a single replica is plenty for the traffic we see and
+# lets the rolling-update strategy swap in the new pod cleanly on every
+# `helm upgrade`.
+replicaCount: 1
 
 resources:
   requests:


### PR DESCRIPTION
Two related changes to the Helm chart used by `.github/workflows/deploy.yml`.

## 1. `charts/values.yaml`

| | before | after |
| --- | --- | --- |
| `replicaCount` | `2` | `1` |
| `image.pullPolicy` | `IfNotPresent` | `Always` |

Rationale:

- **1 replica** — marketing site traffic does not need two pods; the default rolling-update strategy still swaps in the new pod and waits for readiness before terminating the old one.
- **`pullPolicy: Always`** — makes a redeploy against a mutable tag (`dev`, `latest`, `v1`) actually pick up the image that was just pushed, rather than reusing the node-cached layer.

## 2. `charts/templates/deployment.yaml` — add `rollme` annotation

```yaml
template:
  metadata:
    annotations:
      rollme: {{ randAlphaNum 5 | quote }}
```

Every `helm upgrade --install` renders a new random value, so the pod-template spec hash always changes → Kubernetes always rolls the pod → the new pod hits the registry fresh (thanks to `pullPolicy: Always`). Idiomatic Helm pattern, documented at [helm.sh/docs/howto/charts_tips_and_tricks](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments).

## Net effect on the deploy workflow

No changes needed in `.github/workflows/deploy.yml`. The existing:

```bash
helm upgrade --install website ./charts \
  --namespace web --create-namespace \
  --set image.tag=<version> --wait --timeout 5m
```

now always produces:
- exactly one running pod;
- a fresh pull from Docker Hub for the requested tag;
- a guaranteed rollout, even if the tag is identical to the currently-deployed version (e.g. re-running `workflow_dispatch` with `version: dev` right after `cd.yml` pushed a new `dev` image).

## Verification

Rendered locally with `helm template website ./charts --namespace web`:

```
replicas: 1
rollme: "fYVmC"
imagePullPolicy: Always
```

(the `rollme` string is different on each render — as designed.)
