### PR TITLE
ci: auto-deploy to kubernetes on stable release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -86,3 +86,67 @@ jobs:
             ${{ env.DOCKER_HUB_NAMESPACE }}/${{ env.IMAGE_NAME }}:v${{ env.RELEASE_MAJOR }}${{ env.SUFFIX }}
             ${{ env.DOCKER_HUB_NAMESPACE }}/${{ env.IMAGE_NAME }}:v${{ env.RELEASE_MAJOR }}.${{ env.RELEASE_MINOR }}${{ env.SUFFIX }}
             ${{ env.DOCKER_HUB_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ env.RELEASE_VERSION }}
+
+  # Roll the freshly-pushed image out to the OVH cluster. Chained here
+  # rather than triggered by a `release: published` event because events
+  # created via the default GITHUB_TOKEN do not cascade into other
+  # workflows, so a `release:` trigger on release-please releases would
+  # silently never fire. See:
+  # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+  deploy:
+    needs: [resolve-version, docker]
+    # Auto-deploy stable releases only. Dev pushes on `main` rebuild the
+    # `dev` image tag every time, but we don't want every merge to main
+    # to roll the production namespace — the manual 'Deploy to Kubernetes'
+    # workflow is still available to pin any tag (dev, latest, vX.Y.Z).
+    if: needs.resolve-version.outputs.release-type == 'stable'
+    runs-on: ubuntu-latest
+
+    # Serialise deploys so two releases landing back-to-back can't race.
+    concurrency:
+      group: cd-deploy-k8s
+      cancel-in-progress: false
+
+    env:
+      RELEASE_VERSION: ${{ needs.resolve-version.outputs.release-version }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Write kubeconfig
+        env:
+          KUBECONFIG_DATA: ${{ secrets.OVH_KUBECONFIG }}
+        run: |
+          if [ -z "$KUBECONFIG_DATA" ]; then
+            echo "::error::The OVH_KUBECONFIG GitHub Actions secret is empty."
+            echo "Set it under Settings → Secrets and variables → Actions → Secrets."
+            exit 1
+          fi
+          mkdir -p "$HOME/.kube"
+          printf '%s' "$KUBECONFIG_DATA" > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+          kubectl cluster-info
+
+      - name: Helm upgrade
+        run: |
+          echo "Deploying io2060/${{ env.IMAGE_NAME }}:${{ env.RELEASE_VERSION }} to namespace 'web'..."
+          helm upgrade --install website ./charts \
+            --namespace web \
+            --create-namespace \
+            --set image.tag=${{ env.RELEASE_VERSION }} \
+            --wait --timeout 5m
+
+      - name: Show deployed resources
+        if: always()
+        run: |
+          helm status website -n web || true
+          kubectl -n web get deploy,svc,ingress -l app.kubernetes.io/name=website -o wide || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,22 @@
 name: Deploy to Kubernetes
 
+# Manual-only rollout for pinning an arbitrary image tag to the cluster
+# (rollback, redeploy `latest`/`dev`/`v1` floating tags, pin to a
+# specific vX.Y.Z). Automatic deploys for new stable releases are
+# chained off the `docker` job in cd.yml — we can't use a `release:
+# published` trigger here because release-please creates the release
+# with the default GITHUB_TOKEN, and events produced by GITHUB_TOKEN
+# don't cascade into other workflows.
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       version:
-        description: "Image tag to deploy (e.g. v1.2.3, v1, dev, latest)"
+        description: "Image tag to deploy (e.g. 2060-io-website-v2.3.0, v2, dev, latest)"
         required: true
         default: latest
 
 concurrency:
-  group: cd-${{ github.workflow }}
+  group: cd-deploy-k8s
   cancel-in-progress: false
 
 jobs:
@@ -24,14 +29,7 @@ jobs:
       - name: Compute image tag
         id: tag
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            # release-please tags releases 'v1.2.3' and the Docker workflow
-            # in cd.yml pushes io2060/website:v1.2.3 with the same name,
-            # so use the ref name as-is (no 'v' stripping).
-            VERSION="${GITHUB_REF_NAME}"
-          else
-            VERSION="${{ inputs.version }}"
-          fi
+          VERSION="${{ inputs.version }}"
           if [ -z "$VERSION" ]; then
             echo "::error::Could not determine image tag to deploy."
             exit 1


### PR DESCRIPTION
Mirror of [`2060-io/hologram.zone-website#114`](https://github.com/2060-io/hologram.zone-website/pull/114) applied to this repo.

## Problem

Merging a release-please PR into `main` correctly builds and pushes `io2060/website:<version>` to Docker Hub, but the Kubernetes rollout never runs automatically — every release still needs a manual `workflow_dispatch` of **Deploy to Kubernetes**.

## Root cause

`deploy.yml` listened for `release: published`, which sounds right but is silently blocked by a GitHub Actions safety rule:

> Events produced by workflows using the default `GITHUB_TOKEN` do **not** trigger other workflows.
> https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

`release-please` creates the GitHub release using `secrets.GITHUB_TOKEN`, so the `release: published` event fires but is filtered out before any other workflow sees it.

## Fix — chain the rollout in `cd.yml`

Two small moves:

### 1. `cd.yml` — new `deploy` job

Runs after `docker` whenever `resolve-version` reports a stable release. All of the Helm / kubectl setup that used to live in `deploy.yml` moves here:

```yaml
deploy:
  needs: [resolve-version, docker]
  if: needs.resolve-version.outputs.release-type == 'stable'
  runs-on: ubuntu-latest
  concurrency:
    group: cd-deploy-k8s
    cancel-in-progress: false
  env:
    RELEASE_VERSION: ${{ needs.resolve-version.outputs.release-version }}
  steps:
    - uses: actions/checkout@v4
    - uses: azure/setup-kubectl@v4
    - uses: azure/setup-helm@v4
      with: { version: v3.14.0 }
    - name: Write kubeconfig
      env:
        KUBECONFIG_DATA: ${{ secrets.OVH_KUBECONFIG }}
      run: |
        mkdir -p "$HOME/.kube"
        printf '%s' "$KUBECONFIG_DATA" > "$HOME/.kube/config"
        chmod 600 "$HOME/.kube/config"
        kubectl cluster-info
    - name: Helm upgrade
      run: |
        helm upgrade --install website ./charts \
          --namespace web --create-namespace \
          --set image.tag=${{ env.RELEASE_VERSION }} \
          --wait --timeout 5m
```

The `if:` gate is deliberate:

- **stable** releases (release-please merge into `main`) → auto-deploy to the `web` namespace
- **dev** pushes (every other commit to `main`) → still rebuild the `dev` Docker tag but **don't** roll the production namespace; the manual workflow is still available if you want to pin `dev` temporarily

Chaining `needs: docker` also removes the image-availability poll loop that used to live in `deploy.yml` — the deploy job can't start until the push has already finished.

### 2. `deploy.yml` — manual-only

- Drop the `release: published` trigger (it can't fire in practice)
- Keep `workflow_dispatch` for rollback / pinning arbitrary tags (`latest`, `dev`, `v2`, `2060-io-website-v2.3.0`, etc.)
- Align the concurrency group to `cd-deploy-k8s` so a manual rollout and an auto-deploy can't race against each other

## Alternatives considered

- **Swap release-please to a PAT / GitHub App token** — would let `release: published` fire, but you then own a rotating secret. Rejected for a minor surface of this size.
- **`workflow_run` trigger** — can observe `cd.yml` completion, but runs in the base-branch context with fiddlier permission and output-plumbing semantics. Rejected as more complex than the chain.

## Verification

- `helm upgrade` in the `deploy` job uses the exact `RELEASE_VERSION` string pushed as a Docker tag by the preceding `docker` job, so no format mismatch (for `2.3.0` that's `2060-io-website-v2.3.0` as both the image tag and `--set image.tag=`).
- Next merge of a release-please PR should roll `web/website` without human intervention.
- Manual rollout can still be invoked from **Actions → Deploy to Kubernetes → Run workflow** with any existing tag.

## Secrets required (unchanged, already present)

- `DOCKER_HUB_LOGIN`
- `DOCKER_HUB_PWD`
- `OVH_KUBECONFIG`