### PR TITLE
fix: site-scoped CRM secret name (website-secrets → 2060-website-secrets)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Copy to .env.local for local development (.env* is gitignored).
 # In production these come from the chart (RELATICLE_API_URL) and the k8s
-# `website-secrets` Secret, which the deploy workflows populate from the
+# `2060-website-secrets` Secret, which the deploy workflows populate from the
 # RELATICLE_API_TOKEN GitHub Actions secret — do NOT ship a .env file.
 
 # Relaticle CRM — the /contact form posts inquiries here.

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -143,10 +143,10 @@ jobs:
           RELATICLE_API_TOKEN: ${{ secrets.RELATICLE_API_TOKEN }}
         run: |
           kubectl create namespace web --dry-run=client -o yaml | kubectl apply -f -
-          kubectl -n web create secret generic website-secrets \
+          kubectl -n web create secret generic 2060-website-secrets \
             --from-literal=RELATICLE_API_TOKEN="${RELATICLE_API_TOKEN}" \
             --dry-run=client -o yaml | kubectl apply -f -
-          kubectl -n web annotate secret website-secrets \
+          kubectl -n web annotate secret 2060-website-secrets \
             helm.sh/resource-policy=keep --overwrite
 
       - name: Helm upgrade

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,10 +80,10 @@ jobs:
           RELATICLE_API_TOKEN: ${{ secrets.RELATICLE_API_TOKEN }}
         run: |
           kubectl create namespace web --dry-run=client -o yaml | kubectl apply -f -
-          kubectl -n web create secret generic website-secrets \
+          kubectl -n web create secret generic 2060-website-secrets \
             --from-literal=RELATICLE_API_TOKEN="${RELATICLE_API_TOKEN}" \
             --dry-run=client -o yaml | kubectl apply -f -
-          kubectl -n web annotate secret website-secrets \
+          kubectl -n web annotate secret 2060-website-secrets \
             helm.sh/resource-policy=keep --overwrite
 
       - name: Helm upgrade

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -73,7 +73,7 @@ relaticle:
   enabled: true
   # In-cluster Relaticle service (same OVH cluster, namespace `relaticle`).
   apiUrl: http://relaticle.relaticle.svc.cluster.local
-  secretName: website-secrets
+  secretName: 2060-website-secrets
 
 podSecurityContext: {}
 securityContext: {}


### PR DESCRIPTION
## Summary

Renames the k8s Secret used by the `/contact` → Relaticle CRM integration from the generic **`website-secrets`** to the site-scoped **`2060-website-secrets`**.

## Why

`hologram.zone-website` deploys into the same `web` namespace and its CRM integration also used `website-secrets` — so whichever site deployed last would overwrite the other's `RELATICLE_API_TOKEN`, and both pods would read the same secret, attributing CRM records to the wrong service account. Each site now uses its own name, matching the `<site>-website-secrets` convention across the repos:

- `veranafoundation-website-secrets` · `veranacouncil-website-secrets` · `hologram-website-secrets` (2060-io/hologram.zone-website#119) · **`2060-website-secrets`** (this PR)

## Changes
- `charts/values.yaml` — `relaticle.secretName: 2060-website-secrets` (the deployment template reads this value)
- `cd.yml` + `deploy.yml` — the secret-upsert step creates/annotates the new name
- `.env.example` — comment updated

## Migration note
The old `website-secrets` Secret is keep-annotated and becomes unused once both sites deploy with their scoped names — it can then be deleted manually (`kubectl -n web delete secret website-secrets`).
