### PR TITLE
fix: align Foundation/Council separation with strategy defs

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -14,7 +14,7 @@ export default function Footer() {
             An independent research and engineering company. 2060 is a founding
             member of the{" "}
             <a
-              href="https://verana.io"
+              href="https://veranafoundation.org"
               className="prose-link text-fg"
               rel="noopener"
             >

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,7 +37,7 @@ const structuredData = {
       "memberOf": {
         "@type": "Organization",
         "name": "Verana Foundation",
-        "url": "https://verana.io",
+        "url": "https://veranafoundation.org",
       },
     },
     {
@@ -227,7 +227,7 @@ export default function Page() {
           <li className="relative"><span className="block w-2 h-2 rounded-full bg-muted mb-3"></span><strong className="block text-fg">2020</strong><span className="text-muted">Verifiable Trust invented at IIW</span></li>
           <li className="relative"><span className="block w-2 h-2 rounded-full bg-muted mb-3"></span><strong className="block text-fg">2021–22</strong><span className="text-muted">First Hologram PoCs</span></li>
           <li className="relative"><span className="block w-2 h-2 rounded-full bg-muted mb-3"></span><strong className="block text-fg">2023</strong><span className="text-muted">Verana VPR development</span></li>
-          <li className="relative"><span className="block w-2 h-2 rounded-full bg-muted mb-3"></span><strong className="block text-fg">2024</strong><span className="text-muted">Verana Foundation co-founded</span></li>
+          <li className="relative"><span className="block w-2 h-2 rounded-full bg-muted mb-3"></span><strong className="block text-fg">2024</strong><span className="text-muted">Verana Foundation initiated</span></li>
           <li className="relative"><span className="block w-2 h-2 rounded-full bg-muted mb-3"></span><strong className="block text-fg">2025</strong><span className="text-muted">Hologram in market · Verana Testnet</span></li>
           <li className="relative"><span className="block w-2 h-2 rounded-full bg-accent mb-3"></span><strong className="block text-fg">2026</strong><span className="text-muted">Hologram Cloud GA, 15 August</span></li>
         </ol>
@@ -260,7 +260,7 @@ export default function Page() {
               <img src="/assets/verana-logo.svg" alt="" className="card-logo w-8 h-8 flex-shrink-0" width="32" height="32" aria-hidden="true" />
               Verana
             </h3>
-            <p className="text-muted mt-3 flex-1">Open, decentralized infrastructure for trust registries and verifiable governance, stewarded by the Verana Foundation Council. 2060 co-founded it, holds a Council seat, and is the largest single code contributor.</p>
+            <p className="text-muted mt-3 flex-1">Open, decentralized infrastructure for trust registries and verifiable governance. Its specifications are stewarded by the Verana Foundation; the live network is governed and secured by the independent Verana Council. 2060 is a founding member of the Foundation, holds a Council seat, and is the largest single code contributor.</p>
             <a href="https://verana.io" className="prose-link text-fg text-sm mt-5 self-end" rel="noopener">Explore Verana ↗</a>
           </article>
           <article className="card flex flex-col h-full">
@@ -269,7 +269,7 @@ export default function Page() {
               <i className="fa-solid fa-fw fa-file-lines text-2xl card-icon" aria-hidden="true"></i>
               Verifiable Trust &amp; VPR
             </h3>
-            <p className="text-muted mt-3 flex-1">The open specifications that define the category. Verifiable Trust v4 and VPR v4: co-authored by 2060, maintained publicly, adopted by the Council. Apache 2.0.</p>
+            <p className="text-muted mt-3 flex-1">The open specifications that define the category. Verifiable Trust v4 and VPR v4: co-authored by 2060, maintained publicly, owned and hosted by the Verana Foundation. Apache 2.0.</p>
             <a href="/projects#specifications" className="prose-link text-fg text-sm mt-5 self-end">Read the specs →</a>
           </article>
         </div>
@@ -323,13 +323,13 @@ export default function Page() {
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-check text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Production stack shipped</strong>: 6+ open-source components (Apache 2.0) including Hologram App, VS Agent, Generic AI Agent, SDK, and MCP catalog.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-check text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram Messaging App</strong> live on App Store, Google Play, and Huawei AppGallery.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-check text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">5 reference agents</strong> accessible today: Avatar, Gov ID, GitHub, Wise, X.</span></li>
-              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-check text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Verana Trust Network</strong> testnet operational; mainnet on the Foundation's roadmap.</span></li>
+              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-check text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Verana Trust Network</strong> testnet operational; mainnet targeted for Q1 2027.</span></li>
             </ul>
           </div>
           <div>
             <p className="text-xs tracking-wider uppercase text-muted mb-4">Standards &amp; ecosystem</p>
             <ul className="space-y-4 text-muted">
-              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-check text-muted mt-1" aria-hidden="true"></i><span>Founding member and Council seat: <strong className="text-fg">Verana Foundation</strong>.</span></li>
+              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-check text-muted mt-1" aria-hidden="true"></i><span>Founding member: <strong className="text-fg">Verana Foundation</strong> · Council seat: <strong className="text-fg">Verana Council</strong>.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-check text-muted mt-1" aria-hidden="true"></i><span>Active contributors: <strong className="text-fg">OpenWallet Foundation · Trust Over IP · Decentralized Identity Foundation</strong>.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-check text-muted mt-1" aria-hidden="true"></i><span>Speakers and maintainers at the <strong className="text-fg">Internet Identity Workshop</strong>.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-check text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Verifiable Trust v4</strong> and <strong className="text-fg">VPR v4</strong> specifications: public, open, maintained.</span></li>
@@ -398,9 +398,10 @@ export default function Page() {
           <article className="card">
             <p className="text-xs tracking-wider uppercase text-muted">Council / protocol</p>
             <h3 className="display text-lg mt-3">Build on Verana</h3>
-            <p className="text-muted mt-3 text-sm">Neutral public infrastructure for trust registries and verifiable governance. Council seats, validator ops, and ecosystem onboarding.</p>
-            <div className="mt-5">
+            <p className="text-muted mt-3 text-sm">Neutral public infrastructure for trust registries and verifiable governance. Council seats, validator ops, and ecosystem onboarding are handled by the independent Verana Council.</p>
+            <div className="mt-5 flex flex-wrap gap-3">
               <a href="https://verana.io" className="btn" rel="noopener">Verana ↗</a>
+              <a href="https://veranacouncil.org" className="btn" rel="noopener">Verana Council ↗</a>
             </div>
           </article>
         </div>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -73,11 +73,11 @@ export default function Page() {
           </div>
           <div className="md:col-span-8 reading space-y-5 text-e5">
             <p>
-              Verana is a neutral, decentralized Layer-1 protocol for trust registries, credential schemas, and verifiable governance. It is <strong className="text-fg">not</strong> a 2060 product. It is stewarded by the <strong className="text-fg">Verana Foundation</strong> and governed by a <strong className="text-fg">Council of independent member organizations</strong> across sectors and jurisdictions, each holding one vote.
+              Verana is a neutral, decentralized Layer-1 protocol for trust registries, credential schemas, and verifiable governance. It is <strong className="text-fg">not</strong> a 2060 product. Its specifications are stewarded by the <strong className="text-fg">Verana Foundation</strong>, and the live network is governed and secured by the <strong className="text-fg">Verana Council</strong>, an independent association of member organizations across sectors and jurisdictions, each holding one vote.
             </p>
             <p className="text-muted text-xs tracking-wider uppercase pt-4">2060's role in Verana</p>
             <ul className="space-y-3 text-muted">
-              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-star text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Founding member and Council seat.</strong></span></li>
+              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-star text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Founding member of the Verana Foundation; seat in the Verana Council.</strong></span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-code-branch text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Largest single code contributor</strong> to the reference implementation.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-pen-nib text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Lead editor</strong> of the Verifiable Trust and VPR specifications.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-server text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Validator operator</strong> on the Verana Trust Network.</span></li>

--- a/app/team/page.tsx
+++ b/app/team/page.tsx
@@ -32,9 +32,9 @@ export default function Page() {
             <p className="text-muted text-xs tracking-wider uppercase pt-2">That thesis produced</p>
             <ul className="space-y-3 text-muted">
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-file-lines text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Specifications.</strong> The Verifiable Trust and VPR specifications, drafted between 2021 and 2024, now at v4.</span></li>
-              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-network-wired text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">A protocol.</strong> Verana, whose reference implementation 2060 seeded and whose Foundation 2060 co-founded in 2024.</span></li>
+              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-network-wired text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">A protocol.</strong> Verana, whose reference implementation 2060 seeded; its Foundation, initiated in 2024, counts 2060 as a founding member.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-rocket text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">A product line.</strong> Hologram, our commercial stack, in market since 2025 and now on the App Store, Google Play, and Huawei AppGallery.</span></li>
-              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-people-group text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">An ecosystem.</strong> A Council of 15+ independent organizations across sectors and jurisdictions, each with one vote on the protocol's direction.</span></li>
+              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-people-group text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">An ecosystem.</strong> The Verana Council, the independent body that governs and secures the network, targeting 15+ member organizations across sectors and jurisdictions for mainnet launch, each with one vote.</span></li>
             </ul>
             <p className="pt-2 italic">2060 does not own the ecosystem. 2060 invented the category it sits in.</p>
           </div>
@@ -56,7 +56,7 @@ export default function Page() {
                 <p className="text-xs tracking-wider uppercase text-accent-hover mt-1">Co-founder &amp; CEO</p>
               </div>
             </div>
-            <p className="text-muted text-sm mt-5 flex-1">Entrepreneur and visionary technologist. Co-inventor of Verifiable Trust. Principal author of the Verana specifications. Lead of product and ecosystem strategy. Also Co-founder and CEO of the Verana Foundation.</p>
+            <p className="text-muted text-sm mt-5 flex-1">Entrepreneur and visionary technologist. Co-inventor of Verifiable Trust. Principal author of the Verana specifications. Lead of product and ecosystem strategy.</p>
             <div className="mt-5 flex flex-wrap gap-4 text-sm">
               <a href="https://www.linkedin.com/in/fabricerochette/" className="prose-link text-fg" rel="noopener">LinkedIn ↗</a>
               <a href="https://x.com/fabricerochette" className="prose-link text-fg" rel="noopener">X ↗</a>
@@ -71,7 +71,7 @@ export default function Page() {
                 <p className="text-xs tracking-wider uppercase text-accent-hover mt-1">Co-founder &amp; CTO</p>
               </div>
             </div>
-            <p className="text-muted text-sm mt-5 flex-1">Electronic engineer and open-source leader. Maintainer of VS Agent and the Hologram App. Long-time contributor to Credo-TS. Co-founder and CTO of the Verana Foundation.</p>
+            <p className="text-muted text-sm mt-5 flex-1">Electronic engineer and open-source leader. Maintainer of VS Agent and the Hologram App. Long-time contributor to Credo-TS.</p>
             <div className="mt-5 flex flex-wrap gap-4 text-sm">
               <a href="https://www.linkedin.com/in/aogentile/" className="prose-link text-fg" rel="noopener">LinkedIn ↗</a>
               <a href="https://github.com/genaris" className="prose-link text-fg" rel="noopener">GitHub ↗</a>
@@ -197,7 +197,8 @@ export default function Page() {
           </div>
           <div className="md:col-span-8 reading">
             <ul className="space-y-4 text-muted">
-              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-star text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Verana Foundation</strong>: founding member, Council seat (one of 15+), validator operator, lead editor of the Verifiable Trust and VPR specifications.</span></li>
+              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-star text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Verana Foundation</strong>: founding member, lead editor of the Verifiable Trust and VPR specifications.</span></li>
+              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-landmark text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Verana Council</strong>: Council seat (targeting 15+ members for mainnet launch), validator operator on the Verana Trust Network.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-wallet text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">OpenWallet Foundation</strong>: active contributor on Credo-ts and wallet interoperability.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-shield-halved text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Trust Over IP (ToIP)</strong>: participant in governance and trust-registry working groups.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-id-card text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Decentralized Identity Foundation (DIF)</strong>: contributor on DID methods and credential formats.</span></li>


### PR DESCRIPTION
Aligns the public site with the updated strategy definitions (defs.md), which make the Verana Foundation and the Verana Council fully separate entities. Excludes `/investors`, which gets its own refactor next.

## Changes

**Foundation/Council separation**
- Home "Three bets" Verana card: removed the conflated "Verana Foundation Council"; specs are stewarded by the Foundation, the live network is governed and secured by the independent Verana Council.
- Traction section: "Founding member: Verana Foundation · Council seat: Verana Council" (the Council seat is not a Foundation benefit).
- Team ecosystem-seats list: split the single Foundation bullet into separate Foundation and Council bullets.
- Projects Verana section: names the Verana Council as the independent association that governs and secures the network.
- Specs card: Verifiable Trust v4 / VPR v4 are owned and hosted by the Foundation (not "adopted by the Council").
- Mainnet is a network milestone (targeted Q1 2027), not "on the Foundation's roadmap".
- Council CTA card now also links to veranacouncil.org.

**Link targets**
- Verana Foundation links (footer, structured data `memberOf`) now point to veranafoundation.org instead of verana.io.

**Claims**
- Council membership stated as a target — 15+ member organizations for mainnet launch — instead of a current "15+" count.
- Removed "Co-founder and CEO/CTO of the Verana Foundation" from the founder bios.
- "Verana Foundation co-founded in 2024" rephrased as "initiated in 2024" (timeline + team origin section).

Type-check passes (`tsc --noEmit`).