### PR TITLE
fix: Hologram Cloud GA date is Q3 2026, not 15 August 2026

### DIFF
--- a/app/investors/page.tsx
+++ b/app/investors/page.tsx
@@ -32,7 +32,7 @@ export default function Page() {
             <div className="spec-row"><dt>Flagship product</dt><dd><a href="https://hologram.zone" className="prose-link" rel="noopener">Hologram</a>: deploy personal and corporate AI agents that are verifiable, compliant, governable, and multi-user</dd></div>
             <div className="spec-row"><dt>Protocol</dt><dd><a href="https://verana.io" className="prose-link" rel="noopener">Verana</a>: co-founder, Council member, largest code contributor</dd></div>
             <div className="spec-row"><dt>Standards</dt><dd>Verifiable Trust v4 · VPR v4 (co-authored, lead editor)</dd></div>
-            <div className="spec-row"><dt>Stage</dt><dd>Production stack shipped and open-sourced · Hologram Cloud (managed SaaS) GA launching <strong className="text-fg">15 August 2026</strong> · commercial adoption begins at Cloud GA</dd></div>
+            <div className="spec-row"><dt>Stage</dt><dd>Production stack shipped and open-sourced · Hologram Cloud (managed SaaS) GA launching <strong className="text-fg">Q3 2026</strong> · commercial adoption begins at Cloud GA</dd></div>
             <div className="spec-row"><dt>Tech</dt><dd>Open source (Apache 2.0) · W3C VC / DIDComm / MCP / Verana</dd></div>
             <div className="spec-row"><dt>Geography</dt><dd>HQ Tallinn · team distributed across Europe, Asia, and the Americas</dd></div>
             <div className="spec-row"><dt>Investment target</dt><dd>Equity</dd></div>
@@ -113,7 +113,7 @@ export default function Page() {
       <div className="max-w-6xl mx-auto">
         <p className="tag">Traction</p>
         <h2 className="display text-3xl md:text-4xl mt-4">Production Stack Shipped. Cloud GA Next.</h2>
-        <p className="text-muted mt-4 max-w-3xl reading">Technology is shipped and open-sourced. Commercial adoption begins with <strong className="text-fg">Hologram Cloud</strong> GA, scheduled for <strong className="text-fg">15 August 2026</strong>. Until then, running a Hologram agent requires a developer team to deploy from GitHub, which is why the self-hosted footprint today is small by design.</p>
+        <p className="text-muted mt-4 max-w-3xl reading">Technology is shipped and open-sourced. Commercial adoption begins with <strong className="text-fg">Hologram Cloud</strong> GA, scheduled for <strong className="text-fg">Q3 2026</strong>. Until then, running a Hologram agent requires a developer team to deploy from GitHub, which is why the self-hosted footprint today is small by design.</p>
 
         <div className="grid md:grid-cols-2 gap-10 mt-12">
           <div>
@@ -127,12 +127,12 @@ export default function Page() {
           </div>
           <div>
             <p className="text-xs tracking-wider uppercase text-muted mb-4">Pre-cloud adoption (today)</p>
-            <p className="text-muted text-sm leading-relaxed">Small and deliberate by design. Self-hosting a Hologram agent from GitHub today requires an engineering team, which both limits who runs one and is precisely the gate Cloud GA removes. Pre-cloud adoption metrics (self-hosted organizations, GitHub stars, Discord community, external contributors, active pilots and letters of intent) are published alongside commercial metrics at <strong className="text-fg">Hologram Cloud GA on 15 August 2026</strong>.</p>
+            <p className="text-muted text-sm leading-relaxed">Small and deliberate by design. Self-hosting a Hologram agent from GitHub today requires an engineering team, which both limits who runs one and is precisely the gate Cloud GA removes. Pre-cloud adoption metrics (self-hosted organizations, GitHub stars, Discord community, external contributors, active pilots and letters of intent) are published alongside commercial metrics at <strong className="text-fg">Hologram Cloud GA in Q3 2026</strong>.</p>
           </div>
         </div>
 
         <div className="mt-14 border-l-2 border-accent pl-6 py-3 max-w-3xl">
-          <p className="text-xs tracking-wider uppercase text-accent-hover">Hologram Cloud GA: 15 August 2026 (the inflection)</p>
+          <p className="text-xs tracking-wider uppercase text-accent-hover">Hologram Cloud GA: Q3 2026 (the inflection)</p>
           <ul className="mt-3 space-y-2 text-muted text-sm">
             <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-rocket text-fg mt-1" aria-hidden="true"></i><span><strong className="text-fg">Design-partner tenants</strong> live at launch.</span></li>
             <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-rocket text-fg mt-1" aria-hidden="true"></i><span><strong className="text-fg">Consumer Pro ($TBD/month)</strong> and <strong className="text-fg">enterprise managed hosting</strong> live day one.</span></li>
@@ -227,7 +227,7 @@ export default function Page() {
           <div>
             <p className="text-xs tracking-wider uppercase text-muted mb-4">12-month milestones (2060-owned)</p>
             <ul className="space-y-3 text-muted text-sm">
-              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-circle-check text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram Cloud</strong> GA shipped in month 1 (<strong className="text-fg">15 August 2026</strong>).</span></li>
+              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-circle-check text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram Cloud</strong> GA shipped in month 1 (<strong className="text-fg">Q3 2026</strong>).</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-circle-check text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">150+ companies</strong> on Hologram Cloud by month 12.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-circle-check text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">10,000+ Personal AI agents</strong> on the Hologram App by month 12.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-circle-check text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">ARR target</strong> by month 12 (specific figure shared with qualified investors).</span></li>
@@ -249,7 +249,7 @@ export default function Page() {
         <div className="mt-14">
           <p className="text-xs tracking-wider uppercase text-muted mb-4">Why now for 2060</p>
           <ul className="grid md:grid-cols-2 gap-y-4 gap-x-10 max-w-5xl text-muted">
-            <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-bolt text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Cloud GA imminent.</strong> Hologram Cloud launches on <strong className="text-fg">15 August 2026</strong>: the stack moves from developer-deploy to managed SaaS. Investor dollars compound a live commercial surface that is weeks away.</span></li>
+            <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-bolt text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Cloud GA imminent.</strong> Hologram Cloud launches in <strong className="text-fg">Q3 2026</strong>: the stack moves from developer-deploy to managed SaaS. Investor dollars compound a live commercial surface that is weeks away.</span></li>
             <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-box-open text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Production stack shipped.</strong> Technology risk behind us.</span></li>
             <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-wind text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Regulatory tailwind accelerating.</strong></span></li>
             <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-bullseye text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Category forming now.</strong> Reference position is available for the next 12–24 months.</span></li>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -229,7 +229,7 @@ export default function Page() {
           <li className="relative"><span className="block w-2 h-2 rounded-full bg-muted mb-3"></span><strong className="block text-fg">2023</strong><span className="text-muted">Verana VPR development</span></li>
           <li className="relative"><span className="block w-2 h-2 rounded-full bg-muted mb-3"></span><strong className="block text-fg">2024</strong><span className="text-muted">Verana Foundation initiated</span></li>
           <li className="relative"><span className="block w-2 h-2 rounded-full bg-muted mb-3"></span><strong className="block text-fg">2025</strong><span className="text-muted">Hologram in market · Verana Testnet</span></li>
-          <li className="relative"><span className="block w-2 h-2 rounded-full bg-accent mb-3"></span><strong className="block text-fg">2026</strong><span className="text-muted">Hologram Cloud GA, 15 August</span></li>
+          <li className="relative"><span className="block w-2 h-2 rounded-full bg-accent mb-3"></span><strong className="block text-fg">2026</strong><span className="text-muted">Hologram Cloud GA, Q3</span></li>
         </ol>
 
         <img src="/assets/long-term.svg" alt="" aria-hidden="true" className="hero-illustration mt-16" width="3072" height="1536" />
@@ -251,7 +251,7 @@ export default function Page() {
               <img src="/assets/hologram-logo.svg" alt="" className="card-logo w-8 h-8 flex-shrink-0 rounded-md" width="32" height="32" aria-hidden="true" />
               Hologram
             </h3>
-            <p className="text-muted mt-3 flex-1">Our commercial product line: the verifiable trust layer for AI agents, in production today. Messaging app on iOS, Android, and Huawei; agent framework; SDK; enterprise cloud launching 15 August 2026.</p>
+            <p className="text-muted mt-3 flex-1">Our commercial product line: the verifiable trust layer for AI agents, in production today. Messaging app on iOS, Android, and Huawei; agent framework; SDK; enterprise cloud launching Q3 2026.</p>
             <a href="https://hologram.zone" className="prose-link text-fg text-sm mt-5 self-end" rel="noopener">Explore Hologram ↗</a>
           </article>
           <article className="card flex flex-col h-full">
@@ -339,7 +339,7 @@ export default function Page() {
 
         <aside className="mt-14 border-l-2 border-accent pl-6 py-3 max-w-3xl" role="note">
           <p className="text-xs tracking-wider uppercase text-muted">Measured adoption</p>
-          <p className="text-e5 mt-2">Adoption metrics (Hologram Cloud tenants, Personal AI agents, network activity, open-source traction) are published alongside commercial launch at <strong className="text-fg">Hologram Cloud GA on 15 August 2026</strong>.</p>
+          <p className="text-e5 mt-2">Adoption metrics (Hologram Cloud tenants, Personal AI agents, network activity, open-source traction) are published alongside commercial launch at <strong className="text-fg">Hologram Cloud GA in Q3 2026</strong>.</p>
         </aside>
 
         <img src="/assets/tools.svg" alt="" aria-hidden="true" className="hero-illustration mt-16" width="3072" height="1536" />
@@ -390,7 +390,7 @@ export default function Page() {
           <article className="card">
             <p className="text-xs tracking-wider uppercase text-muted">Enterprise / consortium</p>
             <h3 className="display text-lg mt-3">Evaluate Hologram</h3>
-            <p className="text-muted mt-3 text-sm">Our commercial product line. Verifiable AI agents on Apache 2.0 foundations, with enterprise managed hosting launching 15 August 2026.</p>
+            <p className="text-muted mt-3 text-sm">Our commercial product line. Verifiable AI agents on Apache 2.0 foundations, with enterprise managed hosting launching Q3 2026.</p>
             <div className="mt-5">
               <a href="https://hologram.zone" className="btn" rel="noopener">Hologram ↗</a>
             </div>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -46,7 +46,7 @@ export default function Page() {
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-brain text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Generic AI Agent.</strong> Modular LLM agent with MCP, RAG, RBAC, and approval workflows. LLM-agnostic, cloud-agnostic.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-cube text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram SDK</strong> and <strong className="text-fg">Agent Pack schema</strong> for developers building custom Verifiable Services.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-plug text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram MCP catalog</strong>: reusable MCP servers (Wise, GitHub, X, growing).</span></li>
-              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-cloud text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram Cloud</strong>: enterprise hosting, RBAC, SLAs, IAM integration, white-label. GA <strong className="text-fg">15 August 2026</strong>.</span></li>
+              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-cloud text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram Cloud</strong>: enterprise hosting, RBAC, SLAs, IAM integration, white-label. GA <strong className="text-fg">Q3 2026</strong>.</span></li>
             </ul>
             <p className="text-xs text-muted italic pt-2">Open source (Apache 2.0). Built on W3C Verifiable Credentials, DIDComm, MCP, and the Verana Trust Network.</p>
             <div className="pt-4 flex flex-wrap gap-3">


### PR DESCRIPTION
Replace all '15 August 2026' GA references with 'Q3 2026' across home, projects, and investors pages (timeline, hero/CTA copy, spec rows).