### PR TITLE
fix: footer Agent Pack Schema link → hologram-ai-agent repo

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -112,7 +112,7 @@ export default function Footer() {
             </li>
             <li>
               <a
-                href="https://github.com/2060-io/hologram-generic-ai-agent-vs/blob/main/docs/agent-pack-schema.md"
+                href="https://github.com/2060-io/hologram-ai-agent/blob/main/docs/agent-pack-schema.md"
                 className="prose-link"
                 rel="noopener"
               >


### PR DESCRIPTION
Footer "Agent Pack Schema" link updated from the old `hologram-generic-ai-agent-vs` repo to the canonical doc at `2060-io/hologram-ai-agent/blob/main/docs/agent-pack-schema.md`.

Touches only `app/components/Footer.tsx`. `tsc --noEmit` passes.