### PR TITLE
content: Hologram Cloud GA → Q4 2026 + align home/projects Hologram framing

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -229,7 +229,7 @@ export default function Page() {
           <li className="relative"><span className="block w-2 h-2 rounded-full bg-muted mb-3"></span><strong className="block text-fg">2023</strong><span className="text-muted">Verana VPR development</span></li>
           <li className="relative"><span className="block w-2 h-2 rounded-full bg-muted mb-3"></span><strong className="block text-fg">2024</strong><span className="text-muted">Verana Foundation initiated</span></li>
           <li className="relative"><span className="block w-2 h-2 rounded-full bg-muted mb-3"></span><strong className="block text-fg">2025</strong><span className="text-muted">Hologram in market · Verana Testnet</span></li>
-          <li className="relative"><span className="block w-2 h-2 rounded-full bg-accent mb-3"></span><strong className="block text-fg">2026</strong><span className="text-muted">Hologram Cloud GA, Q3</span></li>
+          <li className="relative"><span className="block w-2 h-2 rounded-full bg-accent mb-3"></span><strong className="block text-fg">2026</strong><span className="text-muted">Hologram Cloud GA, Q4</span></li>
         </ol>
 
         <img src="/assets/long-term.svg" alt="" aria-hidden="true" className="hero-illustration mt-16" width="3072" height="1536" />
@@ -251,7 +251,7 @@ export default function Page() {
               <img src="/assets/hologram-logo.svg" alt="" className="card-logo w-8 h-8 flex-shrink-0 rounded-md" width="32" height="32" aria-hidden="true" />
               Hologram
             </h3>
-            <p className="text-muted mt-3 flex-1">Our commercial product line: the verifiable trust layer for AI agents, in production today. Messaging app on iOS, Android, and Huawei; agent framework; SDK; enterprise cloud launching Q3 2026.</p>
+            <p className="text-muted mt-3 flex-1">Our commercial product line: the verifiable trust layer for AI agents, in production today. Messaging app on iOS, Android, and Huawei; agent framework; SDK; enterprise cloud launching Q4 2026.</p>
             <a href="https://hologram.zone" className="prose-link text-fg text-sm mt-5 self-end" rel="noopener">Explore Hologram ↗</a>
           </article>
           <article className="card flex flex-col h-full">
@@ -339,7 +339,7 @@ export default function Page() {
 
         <aside className="mt-14 border-l-2 border-accent pl-6 py-3 max-w-3xl" role="note">
           <p className="text-xs tracking-wider uppercase text-muted">Measured adoption</p>
-          <p className="text-e5 mt-2">Adoption metrics (Hologram Cloud tenants, Personal AI agents, network activity, open-source traction) are published alongside commercial launch at <strong className="text-fg">Hologram Cloud GA in Q3 2026</strong>.</p>
+          <p className="text-e5 mt-2">Adoption metrics (Hologram Cloud tenants, Personal AI agents, network activity, open-source traction) are published alongside commercial launch at <strong className="text-fg">Hologram Cloud GA in Q4 2026</strong>.</p>
         </aside>
 
         <img src="/assets/tools.svg" alt="" aria-hidden="true" className="hero-illustration mt-16" width="3072" height="1536" />
@@ -390,7 +390,7 @@ export default function Page() {
           <article className="card">
             <p className="text-xs tracking-wider uppercase text-muted">Enterprise / consortium</p>
             <h3 className="display text-lg mt-3">Evaluate Hologram</h3>
-            <p className="text-muted mt-3 text-sm">Our commercial product line. Verifiable AI agents on Apache 2.0 foundations, with enterprise managed hosting launching Q3 2026.</p>
+            <p className="text-muted mt-3 text-sm">Our commercial product line. Verifiable AI agents on Apache 2.0 foundations, with enterprise managed hosting launching Q4 2026.</p>
             <div className="mt-5">
               <a href="https://hologram.zone" className="btn" rel="noopener">Hologram ↗</a>
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -251,7 +251,7 @@ export default function Page() {
               <img src="/assets/hologram-logo.svg" alt="" className="card-logo w-8 h-8 flex-shrink-0 rounded-md" width="32" height="32" aria-hidden="true" />
               Hologram
             </h3>
-            <p className="text-muted mt-3 flex-1">Our commercial product line: the verifiable trust layer for AI agents, in production today. Messaging app on iOS, Android, and Huawei; agent framework; SDK; enterprise cloud launching Q4 2026.</p>
+            <p className="text-muted mt-3 flex-1">Our commercial product line: the verifiable trust layer for AI agents, in production today. Hologram AI Agent framework, Hologram Messaging wallet (App Store &amp; Google Play), and SDK; enterprise Hologram Cloud launching Q4 2026.</p>
             <a href="https://hologram.zone" className="prose-link text-fg text-sm mt-5 self-end" rel="noopener">Explore Hologram ↗</a>
           </article>
           <article className="card flex flex-col h-full">
@@ -320,8 +320,8 @@ export default function Page() {
           <div>
             <p className="text-xs tracking-wider uppercase text-muted mb-4">What's live today</p>
             <ul className="space-y-4 text-muted">
-              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-check text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Production stack shipped</strong>: 6+ open-source components (Apache 2.0) including Hologram App, VS Agent, Generic AI Agent, SDK, and MCP catalog.</span></li>
-              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-check text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram Messaging App</strong> live on App Store, Google Play, and Huawei AppGallery.</span></li>
+              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-check text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Production stack shipped</strong>: open-source components (Apache 2.0) — Hologram AI Agent, Hologram Messaging, SDK, and MCP catalog.</span></li>
+              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-check text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram Messaging</strong> live on the App Store and Google Play.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-check text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">5 reference agents</strong> accessible today: Avatar, Gov ID, GitHub, Wise, X.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-check text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Verana Trust Network</strong> testnet operational; mainnet targeted for Q1 2027.</span></li>
             </ul>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -41,12 +41,12 @@ export default function Page() {
             </p>
             <p className="text-muted text-xs tracking-wider uppercase pt-4">The stack</p>
             <ul className="space-y-3 text-muted">
-              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-mobile-screen text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram Messaging App.</strong> Verifiable User Agent for iOS, Android, and Huawei. Private messaging, credential wallet, Proof-of-Trust resolution.</span></li>
-              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-robot text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">VS Agent.</strong> DIDComm agent framework with credential management and DID lifecycle.</span></li>
-              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-brain text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Generic AI Agent.</strong> Modular LLM agent with MCP, RAG, RBAC, and approval workflows. LLM-agnostic, cloud-agnostic.</span></li>
+              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-mobile-screen text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram Messaging.</strong> A DIDComm wallet and messaging app (App Store &amp; Google Play): private messaging, credential wallet, device-bound auth, and the channel for connecting to Hologram AI Agents.</span></li>
+              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-robot text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram AI Agent.</strong> Verifiable-service framework for decentralized LLM agents: connect any LLM and MCP tools, credential-based authentication, role- and purpose-based access control, and approval workflows. LLM- and cloud-agnostic.</span></li>
+              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-brain text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram VUA.</strong> A smoother AG-UI interface for using Hologram AI Agents (in development); today agents are reached over DIDComm via Hologram Messaging.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-cube text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram SDK</strong> and <strong className="text-fg">Agent Pack schema</strong> for developers building custom Verifiable Services.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-plug text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram MCP catalog</strong>: reusable MCP servers (Wise, GitHub, X, growing).</span></li>
-              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-cloud text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram Cloud</strong>: enterprise hosting, RBAC, SLAs, IAM integration, white-label. GA <strong className="text-fg">Q4 2026</strong>.</span></li>
+              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-cloud text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram Cloud</strong>: enterprise hosting, role- and purpose-based access control, SLAs, IAM integration, white-label. GA <strong className="text-fg">Q4 2026</strong>.</span></li>
             </ul>
             <p className="text-xs text-muted italic pt-2">Open source (Apache 2.0). Built on W3C Verifiable Credentials, DIDComm, MCP, and the Verana Trust Network.</p>
             <div className="pt-4 flex flex-wrap gap-3">
@@ -79,7 +79,7 @@ export default function Page() {
             <ul className="space-y-3 text-muted">
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-star text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Founding member of the Verana Foundation; seat in the Verana Council.</strong></span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-code-branch text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Largest single code contributor</strong> to the reference implementation.</span></li>
-              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-pen-nib text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Lead editor</strong> of the Verifiable Trust and VPR specifications.</span></li>
+              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-pen-nib text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Lead author</strong> of the Verifiable Trust and VPR specifications.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-server text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Validator operator</strong> on the Verana Trust Network.</span></li>
             </ul>
             <p>
@@ -104,7 +104,7 @@ export default function Page() {
           </div>
           <div className="md:col-span-8 reading space-y-5 text-e5">
             <p>
-              The specifications that define the Verifiable Trust category. Public, openly licensed, maintained through the Verana Foundation's editorial process with 2060 as lead editor.
+              The specifications that define the Verifiable Trust category. Public, openly licensed, maintained through the Verana Foundation's editorial process with 2060 as lead author.
             </p>
             <div className="grid md:grid-cols-2 gap-4 pt-2">
               <a href="https://github.com/verana-labs/verifiable-trust-spec" className="card flex flex-col h-full text-fg" rel="noopener">
@@ -141,7 +141,7 @@ export default function Page() {
               <i className="fa-brands fa-fw fa-github text-2xl" aria-hidden="true"></i>
               github.com/2060-io
             </h3>
-            <p className="text-muted text-sm mt-3 flex-1">2060's commercial and experimental projects, including the Hologram stack, VS Agent, Generic AI Agent, SDK, and MCP catalog.</p>
+            <p className="text-muted text-sm mt-3 flex-1">2060's commercial and experimental projects, including the Hologram stack (Hologram AI Agent, Hologram Messaging), SDK, and MCP catalog.</p>
             <span className="prose-link text-fg text-sm mt-4 self-end">Browse ↗</span>
           </a>
           <a href="https://github.com/verana-labs" className="card flex flex-col h-full text-fg" rel="noopener">

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -46,7 +46,7 @@ export default function Page() {
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-brain text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Generic AI Agent.</strong> Modular LLM agent with MCP, RAG, RBAC, and approval workflows. LLM-agnostic, cloud-agnostic.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-cube text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram SDK</strong> and <strong className="text-fg">Agent Pack schema</strong> for developers building custom Verifiable Services.</span></li>
               <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-plug text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram MCP catalog</strong>: reusable MCP servers (Wise, GitHub, X, growing).</span></li>
-              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-cloud text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram Cloud</strong>: enterprise hosting, RBAC, SLAs, IAM integration, white-label. GA <strong className="text-fg">Q3 2026</strong>.</span></li>
+              <li className="flex items-start gap-3"><i className="fa-solid fa-fw fa-cloud text-muted mt-1" aria-hidden="true"></i><span><strong className="text-fg">Hologram Cloud</strong>: enterprise hosting, RBAC, SLAs, IAM integration, white-label. GA <strong className="text-fg">Q4 2026</strong>.</span></li>
             </ul>
             <p className="text-xs text-muted italic pt-2">Open source (Apache 2.0). Built on W3C Verifiable Credentials, DIDComm, MCP, and the Verana Trust Network.</p>
             <div className="pt-4 flex flex-wrap gap-3">


### PR DESCRIPTION
Updates the **home** and **projects** pages.

**Cloud GA date**
- Hologram Cloud GA Q3 → **Q4 2026** (timeline, Hologram card, measured-adoption note, CTA on home; Hologram Cloud line on projects).

**Hologram framing aligned to the current 3-module model (defs.md)**
- Drop **Huawei** — Hologram Messaging is on the App Store & Google Play only.
- **Generic AI Agent → Hologram AI Agent**; **Hologram App → Hologram Messaging**.
- Projects Hologram stack now lists the three modules: **Hologram AI Agent** (framework), **Hologram Messaging** (DIDComm wallet/app), **Hologram VUA** (AG-UI, in development). **VS Agent** removed from the Hologram product list (it's the Verana reference runtime — no Verana/2060 mixing).
- Hologram Messaging described as a DIDComm wallet/app (not "the VUA").
- `RBAC` → **role- and purpose-based access control**; **lead editor → lead author**.

Touches `app/page.tsx` and `app/projects/page.tsx`. `tsc --noEmit` passes.